### PR TITLE
forbid empty string in add form

### DIFF
--- a/src/manager/index.html
+++ b/src/manager/index.html
@@ -48,7 +48,7 @@
                     <label for="providerDropdown" <%= translateElement("cm_dialog_providers") %></label>
                     <select id="providerDropdown"></select><br>
                     <label for="channelNameField" <%= translateElement("cm_dialog_username") %></label>
-                    <input type="text" id="channelNameField"><br>
+                    <input type="text" id="channelNameField" required><br>
                     <div id="loadingWrapper" hidden>
                         <progress <%= translateElement("cm_dialog_loading") %></progress><br>
                     </div>


### PR DESCRIPTION
Submitting the add form without filling the channel's or user's name would make the dialog hang until canceled. This pull request simply declares the text field as required.