### PR TITLE
Fix context menu buttons

### DIFF
--- a/src/background/list.js
+++ b/src/background/list.js
@@ -161,7 +161,7 @@ class ListView extends EventTarget {
                 emit(this, "opencm");
                 break;
             case "add":
-                emit(this, "addchannel", event.payload.type, event.payload.login);
+                emit(this, "addchannel", event.payload.login, event.payload.type);
                 break;
             case "pause":
             case "resume":

--- a/src/list/components/channel-context.jsx
+++ b/src/list/components/channel-context.jsx
@@ -37,7 +37,7 @@ const ChannelContextPanel = (props) => {
     }
     if(props.providerEnabled) {
         if(props.external) {
-            items.push(<ContextItem label="context_add" key="add" onCLick={ () => props.onAdd(props.id) }/>);
+            items.push(<ContextItem label="context_add" key="add" onClick={ () => props.onAdd(props.id) }/>);
         }
         else {
             if(props.liveState === LiveState.LIVE) {
@@ -48,7 +48,11 @@ const ChannelContextPanel = (props) => {
         }
     }
     return ( <ContextList title={ props.uname } onClose={ props.onClose }>
-        <ContextItem label="openChannel"/>
+        <ContextItem label="openChannel" onClick={ () => props.onOpen({
+	    url: props.url,
+	    id: props.id,
+	    external: props.external
+	}) }/>
         { items }
         <ContextItem label="context_copy" onClick={ () => props.onCopy({
             url: props.url,

--- a/src/manager/index.html
+++ b/src/manager/index.html
@@ -48,7 +48,7 @@
                     <label for="providerDropdown" <%= translateElement("cm_dialog_providers") %></label>
                     <select id="providerDropdown"></select><br>
                     <label for="channelNameField" <%= translateElement("cm_dialog_username") %></label>
-                    <input type="text" id="channelNameField"><br>
+                    <input type="text" id="channelNameField" required><br>
                     <div id="loadingWrapper" hidden>
                         <progress <%= translateElement("cm_dialog_loading") %></progress><br>
                     </div>


### PR DESCRIPTION
In the context menu (right click on a channel in the popup), the "Open Channel" and "Add Channel" buttons were not working.