### PR TITLE
Fix tab artifact on resize

### DIFF
--- a/src/content/shared.css
+++ b/src/content/shared.css
@@ -42,18 +42,16 @@ body {
 .inline-list {
     padding: 0;
     margin: 0;
-    display: inline-block;
+    display: flex;
+    flex-direction: row;
 }
 
 .inline-list > li {
-    display: inline;
     list-style-type: none;
 }
 
 .right {
     text-align: right;
-    flex-grow: 1;
-    flex-shrink: 0;
 }
 
 [hidden] {
@@ -66,6 +64,8 @@ body {
 /* TOPBAR */
 .topbar {
     display: flex;
+    flex-direction: row;
+    justify-content: space-between;
     background: var(--accent-dark-bg);
 }
 

--- a/src/content/shared.css
+++ b/src/content/shared.css
@@ -52,6 +52,9 @@ body {
 
 .right {
     text-align: right;
+    justify-content: end;
+    flex-grow: 1;
+    flex-shrink: 0;
 }
 
 [hidden] {
@@ -65,7 +68,6 @@ body {
 .topbar {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
     background: var(--accent-dark-bg);
 }
 


### PR DESCRIPTION
When the popup changed width, the "Explore" tab would briefly appear on a second row.
These changes use CSS3's flexbox to recreate the same layout more reliably.