### PR TITLE
Some style fixes in channels' manager

### DIFF
--- a/src/manager/channels-manager.css
+++ b/src/manager/channels-manager.css
@@ -100,7 +100,7 @@ main {
     color: var(--accent-light-text);
 }
 
-.selectableItemsList > option:hover:not(:last-child) {
+.selectableItemsList > option:hover {
     border-bottom: 1px solid var(--inverted-separator);
 }
 

--- a/src/manager/index.html
+++ b/src/manager/index.html
@@ -16,7 +16,7 @@
     <body>
         <main class="tabbed loading">
             <nav class="topbar">
-                <ul class="tabstrip inline-list" role="tablist">
+                <ul class="tabstrip inline-list toolbar" role="tablist">
                     <li role="presentation"><a href="#channels" role="tab" aria-controls="channels" data-tab="1" <%= translateElement("cm_tab_channels") %></a></li>
                     <li role="presentation"><a href="#users" role="tab" aria-controls="users" data-tab="2" <%= translateElement("cm_tab_users") %></a></li>
                 </ul>


### PR DESCRIPTION
These changes intend to fix some inconsistencies in the channels' manager:
 - The tabs react on hover to reflect the tabs' behavior in the popup.
- Added back the missing bottom border on the last channel when hovering 