### PR TITLE
Change scrolling behavior

### DIFF
--- a/src/list/components/navigateable-list.jsx
+++ b/src/list/components/navigateable-list.jsx
@@ -102,7 +102,7 @@ export class NavigateableList extends React.Component {
             });
         });
         return (
-            <ul onKeyUp={ (e) => this.handleKey(e) } tabIndex={ 0 } ref={ (e) => {
+            <ul onKeyUp={ (e) => this.handleKey(e) } className="scrollable" tabIndex={ 0 } ref={ (e) => {
                 this.list = e;
             } }>
                 { mappedChildren }

--- a/src/list/list.css
+++ b/src/list/list.css
@@ -7,7 +7,7 @@
     --big-avatar: 30px;
     --small-avatar: 1em;
     --avatar-size: var(--big-avatar);
-    --topbard-height: 2.2em;
+    --topbar-height: 2.2em;
 }
 
 body {
@@ -39,8 +39,6 @@ a {
 }
 
 nav {
-    position: sticky;
-    top: 0;
     z-index: 10;
     min-width: -moz-max-content;
 }
@@ -60,9 +58,9 @@ nav {
     display: block;
 }
 
-.exploreprovider {
-    position: sticky;
-    top: var(--topbar-height);
+.scrollable {
+    max-height: 500px;
+    overflow-y: auto;
 }
 
 .tabcontent {


### PR DESCRIPTION
This is a suggestion to change the way the scrollbar works in the popup. Instead of having the scrollbar on the whole popup and fixing the header, theses changes make only the inner content scrollable. It works by setting an inner height, making sure the content never overflows the popup.

It fixes the issue introduced in 1816c6f9202bafff81f49944f2b8b48bac0a04bf as well as another issue where the extra info was visible through the selector ([issue on bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1398823)).

However, because it is limited by the biggest possible header (tabs, search field and selector visible), the inner content is about 70px shorter.

I also fixed a typo I came across.